### PR TITLE
Fixing buildozer command of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,6 @@ PYTHON = python
 theming:
 	$(PYTHON) -m kivy.atlas pydelhiconf/data/default 1024 tools/theming/*.png
 apk:
-	buildozer android_new debug
+	buildozer android debug
 apk_release:
-	buildozer android_new release
+	buildozer android release

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,6 @@ PYTHON = python
 theming:
 	$(PYTHON) -m kivy.atlas pydelhiconf/data/default 1024 tools/theming/*.png
 apk:
-	bulldozer android_new debug
+	buildozer android_new debug
 apk_release:
 	buildozer android_new release


### PR DESCRIPTION
Fixed Makefile call of buildozer command 'buildozer' and android target:

From
```
...
apk:
	bulldozer android_new debug
apk_release:
	buildozer android_new release
```

To: 
```
...
apk:
	buildozer android debug
apk_release:
	buildozer android release
```
